### PR TITLE
BLD: remove Google Analytics, add Cloudflare

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "react": "^17.0.2",
     "react-bootstrap": "^2.0.0-rc.0",
     "react-dom": "^17.0.2",
-    "react-ga4": "^1.4.1",
     "react-router-dom": "^5.3.0",
     "react-router-hash-link": "^2.4.3",
     "react-scripts": "4.0.3"

--- a/public/index.html
+++ b/public/index.html
@@ -26,6 +26,10 @@ Kindly aims to make children feel safer by leveraging the latest advances in tec
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
 
+    <!-- Cloudflare Web Analytics -->
+    <script defer src='https://static.cloudflareinsights.com/beacon.min.js' data-cf-beacon='{"token": "fb6f5378f9fa492e9b989811ee2b9323"}'></script>
+    <!-- End Cloudflare Web Analytics -->
+
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">
       // Single Page Apps for GitHub Pages

--- a/src/App.js
+++ b/src/App.js
@@ -3,10 +3,6 @@ import {Switch, Route} from "react-router-dom";
 import Main from "./Main";
 import Form from "./Form";
 import Contribute from "./Contribute";
-import ReactGA from "react-ga4";
-
-ReactGA.initialize("G-S6WPR7VPDE");
-ReactGA.send("pageview");
 
 const App = () => {
   return (

--- a/yarn.lock
+++ b/yarn.lock
@@ -9772,11 +9772,6 @@ react-error-overlay@^6.0.9:
   resolved "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz"
   integrity sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew==
 
-react-ga4@^1.4.1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/react-ga4/-/react-ga4-1.4.1.tgz#6ee2a2db115ed235b2f2092bc746b4eeeca9e206"
-  integrity sha512-ioBMEIxd4ePw4YtaloTUgqhQGqz5ebDdC4slEpLgy2sLx1LuZBC9iYCwDymTXzcntw6K1dHX183ulP32nNdG7w==
-
 react-is@^16.3.2, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz"


### PR DESCRIPTION
Through the submission of Kindly as a Digital Public Good, we learned that Google Analytics is by default not GDPR-compliant. Because we care about user privacy, and a smooth user experience (where we want to avoid the nightmare UI of clicking through banners and accepting/rejecting cookies), we are hereby switching to [Cloudflare Web Analytics](https://www.cloudflare.com/web-analytics/) that is designed as a free, privacy-first analytics for any website.

Cc: @nathanbaleeta, @nathanfletcher, @amreenp7 