### PR TITLE
BLD: CI pushes downstream on every commit to main

### DIFF
--- a/.github/workflows/push-downstream.yml
+++ b/.github/workflows/push-downstream.yml
@@ -1,0 +1,42 @@
+name: Push Downstream
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  push_downstream:
+    runs-on: ubuntu-latest
+    # Only to be run on commits to main branch AND when in the upstream repository
+    if: github.ref == 'refs/heads/main' && github.repository == 'unicef/kindly-website'
+
+    steps:
+      # Checkout downstream repo at lacabra/kindly-website
+      - uses: actions/checkout@v2
+        with: 
+          repository: lacabra/kindly-website
+          token: ${{ secrets.LACABRA_TOKEN }}  # Personal Access Token with workflow scope
+
+      - name: fetch and push
+        run: |
+          # Set upstream to this repository
+          git remote add upstream https://github.com/${GITHUB_REPOSITORY}
+
+          # Verify upstream is correct, you should see the URL for the upstream fetch and push 
+          git remote -v
+
+          # Get all recent branches and commits from the upstream
+          git fetch upstream
+
+          # Make sure we are on the main branch
+          git checkout main
+
+          # Merge the branches and commits from the upstream
+          git merge upstream/main
+                        
+          # helpful for debugging
+          git show-ref
+        
+          # Push changes to main branch of downstream repo. This works because we have 
+          # checked out the repo with actions/checkout@v2 and the right Personal Access Token
+          git push origin main


### PR DESCRIPTION
This PR adds a new workflow for GitHub Actions that does the following:

- Only runs for commits on the `main` branch (and only runs on the upstream, so that the file can be included as is in the downstream)
- Pushes updates downstream to [lacabra/kindly-website](https://github.com/lacabra/kindly-website)

Refer to the inline documentation in the YAML file for additional details.

This has been worked out through trial and error in the following two repositories:
- [unicef/publicgoods-test](https://github.com/unicef/publicgoods-test) - Upstream
- [lacabra/publicgoods-test](https://github.com/lacabra/publicgoods-test) - Downstream

In particular refer to the last commit on the upstream and observe how the downstream is updated automatically.

The above two test repos will be deleted upon merging of this PR.