### PR TITLE
MAINT: only run contrib-counter on unicef repo

### DIFF
--- a/.github/workflows/contribution-counter.yml
+++ b/.github/workflows/contribution-counter.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   count_contributions:
     runs-on: ubuntu-latest
+    if: github.repository == 'unicef/kindly-website'
 
     steps:
       - name: Checkout unicef/kindly repo into modeling/dataset file


### PR DESCRIPTION
Similar to the condition found in #27, this CI script only runs in the upstream