### PR TITLE
 Actions/Checkout with token

### DIFF
--- a/.github/workflows/contribution-counter.yml
+++ b/.github/workflows/contribution-counter.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Checkout current repo
         uses: actions/checkout@v2
+        with:
+          token: ${{secrets.GH_ACTION_PAT}}
 
       - name: Update counter
         env:

--- a/src/components/ContributionCounter.js
+++ b/src/components/ContributionCounter.js
@@ -1,5 +1,5 @@
 const ContributionCounter = () => {
-  const COUNTER = 62;
+  const COUNTER = 182;
 
   return (
     <div>


### PR DESCRIPTION
Workflow still failing with protected branch permissions. Setting actions/checkout to use the PAT instead of default token