### PR TITLE
MAINT: update credentials

### DIFF
--- a/.github/workflows/push-downstream.yml
+++ b/.github/workflows/push-downstream.yml
@@ -14,8 +14,8 @@ jobs:
       # Checkout downstream repo at lacabra/kindly-website
       - uses: actions/checkout@v2
         with: 
-          repository: lacabra/kindly-website
-          token: ${{ secrets.LACABRA_TOKEN }}  # Personal Access Token with workflow scope
+          repository: dpgabot/kindly-website
+          token: ${{ secrets.DPGABOT_TOKEN }}  # Personal Access Token with workflow scope
 
       - name: fetch and push
         run: |


### PR DESCRIPTION
After migrating `lacabra/kindly-website` to `dpgabot/kindly-website` the repository name is updated accordingly in the GitHub Actions workflow, and the secret has already been replaced by a Personal Access Token (PAT) issued by the dpgabot account.