### PR TITLE
MAINT: disable deployment on GH Pages

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -43,24 +43,24 @@ jobs:
           name: production-files
           path: ./build
 
-  deploy:
-    name: Deploy
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
+  # deploy:
+  #   name: Deploy
+  #   needs: build
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == 'refs/heads/main'
 
-    steps:
-      - name: Download artifact
-        uses: actions/download-artifact@v2
-        with:
-          name: production-files
-          path: ./build
+  #   steps:
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v2
+  #       with:
+  #         name: production-files
+  #         path: ./build
 
-      - name: Recreate CNAME
-        run: echo kindly.unicef.io > ./build/CNAME
+  #     - name: Recreate CNAME
+  #       run: echo kindly.unicef.io > ./build/CNAME
 
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./build
+  #     - name: Deploy to gh-pages
+  #       uses: peaceiris/actions-gh-pages@v3
+  #       with:
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         publish_dir: ./build


### PR DESCRIPTION
Given that this website is deployed through Cloudflares Pages, this pull request disables the deployment on GitHub Pages to avoid confusion. Approval and merge of this PR should be followed by the removal of the branch `gh-pages`