### PR TITLE
Adding 'prompt' to formData

### DIFF
--- a/src/components/KindlyForm.js
+++ b/src/components/KindlyForm.js
@@ -77,6 +77,7 @@ function KindlyForm(props) {
     formData.append("text", inputText);
     formData.append("intent", value);
     formData.append("row", refRow.current);
+    formData.append("prompt", prompts);
 
     fetch(SCRIPT_URL, {method: "POST", body: formData})
       .then(async (response) => {


### PR DESCRIPTION
Adding prompts to the form data to populate in Google Sheets form to allow for contextual understanding of responses. 